### PR TITLE
ElePHPone: README link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Content-Type: application/json; charset=utf-8
 
 Of course, since it's a random quote, the link to the quote audio might be different.
 
-[Tropo](https://www.tropo.com)
-[PHP Community](http://phpcommunity.org)
-[ElePHPone on GitHub](https://github.com/elephpone/elephpone)à
-[Composer](https://getcomposer.org)
-[Zend Framework 2](https://framework.zend.com)
+[Tropo]: https://www.tropo.com
+[PHP Community]: http://phpcommunity.org
+[ElePHPone on GitHub]: https://github.com/elephpone/elephpone
+[Composer]: https://getcomposer.org
+[Zend Framework 2]: https://framework.zend.com
 
 
 Installation notes on Windows


### PR DESCRIPTION
In PR #3 I overlooked the changes made to the prepared links made at the bottom of the document. I reverted those changes so the links in the document were working again.

For more information about these prepared links, see the section on "link label" in the [official Markdown documentation](http://daringfireball.net/projects/markdown/syntax#link).