### PR TITLE
adding IsManualIntegration

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -77,7 +77,8 @@
                     ],
                     "properties": {
                         "RepoUrl": "[variables('sourcecontrol:repo')]",
-                        "branch": "[variables('sourcecontrol:branch')]"
+                        "branch": "[variables('sourcecontrol:branch')]",
+                        "IsManualIntegration": true
                     }
                 }
             ]


### PR DESCRIPTION
When using Continuous Delivery from a repo you don't have admin access on, the deployment will fail. Will need to add instructions on how to change this to false, if the repository is forked.
